### PR TITLE
Use compatible usage of xmllint.

### DIFF
--- a/ingest
+++ b/ingest
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# method to retrieve xpath from xml file
+function getXPath 
+{
+   if [ $# -ne 2 ]
+   then
+      echo "Wrong parameters: $0 <xpath> <file>"
+   else
+      xpath=$1
+      file=$2
+      echo "cat $xpath"|xmllint --shell $file | grep -v "^/ >" | grep -v " -*"
+   fi
+}
+
 FILEPATH=$1
 shift 1
 
@@ -13,8 +26,8 @@ curl -X POST --basic -u ${DLOGIN}:${DPASS} --data-binary @${FILEPATH} \
   -o out.xml \
   "http://${DHOST}/odata/v1/Ingests"
 
-id=`xmllint --nsclean --xpath "//*[name()='d:Id']/text()" out.xml`
-remote_md5=`xmllint --nsclean --xpath "//*[name()='d:MD5']/text()" out.xml | tr [:upper:] [:lower:]`
+id=$(getXPath "//*[name()='d:Id']/text()" out.xml)
+remote_md5=$(getXPath "//*[name()='d:MD5']/text()" out.xml | tr [:upper:] [:lower:])
 rm out.xml
 
 if [ "$md5" != "$remote_md5" ] ; then


### PR DESCRIPTION
Hi Jonathan, 
Following a problem encountered by ops, I updated a bit your script to also be supported by RedHat/CentOs 6.7 operating systems.

The --xpath parameter is supported with libxml2 v20903. RedHat/CentOS 6.7 embeds older version (20706) that does not support this parameter even is xpath management is already supported...